### PR TITLE
Only add sensors to HK that are supported by the connected device

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "class-methods-use-this": 0,
     "import/no-extraneous-dependencies": 0,
     "scanjs-rules/call_connect": 0,
+    "unicorn/no-array-reduce": 0,
     "unicorn/switch-case-braces": ["error", "avoid"],
 
     "@typescript-eslint/restrict-template-expressions": 0,

--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
-# Homebridge integration for AEG Wellbeing
+# Homebridge Integration for AEG Wellbeing
 
-This is the AEG Wellbeing plugin for [Homebridge](https://github.com/nfarina/homebridge). 
+The AEG Wellbeing plugin for [Homebridge](https://github.com/nfarina/homebridge) adds support for AEG Wellbeing Air Purifiers and all their sensors (Air Quality, Temperature, Humidity, CO2, Filter Life) to your Home app. This plugin has been tested on the following models:
 
-## Supported devices
-This plugin will add support for AEG Wellbeing Air Purifiers and all their sensors (Air Quality, Temperature, Humidity, CO2, Filter Life) to your Home app. It has been tested on the following models:
+- AEG Wellbeing AX9
+- AEG Wellbeing AX5
 
- - AEG Wellbeing AX9
- - AEG Wellbeing AX5
-
-_If you have another model in the range and it works for you, then please add it to this list._
+If you have another model in the range and it works for you, please add it to this list.
 
 ## Configuration
-Use Homebridge UI to configure and set your username and password. This is the same as used in the AEG Wellbeing App.
+To configure the plugin, use the Homebridge UI to set your username and password, which are the same credentials you use in the AEG Wellbeing App.
 
 ### Ionizer
-Currently, there is no support for ionizer in HomeKit, so we mapped this to Swing Mode instead. 
-Use oscilliator/swing mode to control ionizer on/off.
+Please note that ionizer is currently not supported in HomeKit, so we have mapped it to Swing Mode. Use oscilliator/swing mode to control the ionizer on/off.
 
 ---
 
-*This is plugin is forked from [homebridge-electrolux-wellbeing](https://github.com/baboons/homebridge-electrolux-wellbeing). It fixes a few bugs and now only adds sensors supported by the connected device, which veries by model. If you have an Electrolux Wellbeing Air Purifier then this plugin should work with your device as both brands use a common API.*
-
+This plugin is a fork of [homebridge-electrolux-wellbeing](https://github.com/baboons/homebridge-electrolux-wellbeing). It fixes a few bugs and only adds sensors supported by the connected device, which varies by model. If you have an Electrolux Wellbeing Air Purifier, then this plugin should work with your device as both brands use a common API.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Homebridge integration for AEG Wellbeing
 
-This is the AEG Wellbeing plugin for [Homebridge](https://github.com/nfarina/homebridge). This plugin will add support for AEG Air Purifiers with all their sensors (Air Quality, Temperature, Humidity, CO2) to your Home app. 
+This is the AEG Wellbeing plugin for [Homebridge](https://github.com/nfarina/homebridge). 
+
+## Supported devices
+This plugin will add support for AEG Wellbeing Air Purifiers and all their sensors (Air Quality, Temperature, Humidity, CO2, Filter Life) to your Home app. It has been tested on the following models:
+
+ - AEG Wellbeing AX9
+ - AEG Wellbeing AX5
+
+_If you have another model in the range and it works for you, then please add it to this list._
 
 ## Configuration
-Use Homebridge UI to configure and set your username and password.
+Use Homebridge UI to configure and set your username and password. This is the same as used in the AEG Wellbeing App.
 
 ### Ionizer
 Currently, there is no support for ionizer in HomeKit, so we mapped this to Swing Mode instead. 
@@ -11,4 +19,5 @@ Use oscilliator/swing mode to control ionizer on/off.
 
 ---
 
-*This is plugin is forked from [homebridge-electrolux-wellbeing](https://github.com/baboons/homebridge-electrolux-wellbeing). It fixes a few bugs and removes the light sensor. The plugin has been tested using an AEG AX9 Air Purifier, it should in theory work with any AEG or Electolux purifier that uses their common API.*
+*This is plugin is forked from [homebridge-electrolux-wellbeing](https://github.com/baboons/homebridge-electrolux-wellbeing). It fixes a few bugs and now only adds sensors supported by the connected device, which veries by model. If you have an Electrolux Wellbeing Air Purifier then this plugin should work with your device as both brands use a common API.*
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge AEG Wellbeing",
   "name": "homebridge-aeg-wellbeing",
-  "version": "1.1.2-beta.2",
+  "version": "1.1.2",
   "description": "Connects to your AEG Air Purifier",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge AEG Wellbeing",
   "name": "homebridge-aeg-wellbeing",
-  "version": "1.1.2-beta.1",
+  "version": "1.1.2-beta.2",
   "description": "Connects to your AEG Air Purifier",
   "license": "Apache-2.0",
   "repository": {

--- a/src/brand.ts
+++ b/src/brand.ts
@@ -1,0 +1,3 @@
+export const MANUFACTURER = 'AEG'
+export const PLUGIN_NAME = 'aeg-wellbeing';
+export const PLATFORM_NAME = 'AEGWellbeing';

--- a/src/brand.ts
+++ b/src/brand.ts
@@ -1,3 +1,4 @@
 export const MANUFACTURER = 'AEG'
 export const PLUGIN_NAME = 'aeg-wellbeing';
 export const PLATFORM_NAME = 'AEGWellbeing';
+export const MODEL_PREFIX = 'AX-'

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 import find from 'lodash/find';
 
 import createClient from './api';
-import { MANUFACTURER, PLATFORM_NAME,PLUGIN_NAME } from './brand'
+import { MANUFACTURER, MODEL_PREFIX, PLATFORM_NAME,PLUGIN_NAME } from './brand'
 import { Appliance, WellbeingApi, WorkModes } from './types';
 
 // AX9 fans support speeds from [1, 9].
@@ -34,6 +34,8 @@ const arrayToObject = arr => {
   arr.forEach(element => obj[element] = true); // eslint-disable-line no-return-assign
   return obj;
 };
+
+const fixModelPrefix = (model) => `${MODEL_PREFIX}${model.match(/(\d+)/)[0]}`
 
 class wellbeingPlatform implements DynamicPlatformPlugin {
   private client?: AxiosInstance;
@@ -457,6 +459,7 @@ class wellbeingPlatform implements DynamicPlatformPlugin {
     const uuid = hap.uuid.generate(pncId);
     const hasFeature = arrayToObject(features)
 
+    this.log.debug(modelName, '->', fixModelPrefix(modelName))
     this.log.debug(name, 'features: ', features)
 
     if (this.isAccessoryRegistered(name, uuid)) {
@@ -483,7 +486,7 @@ class wellbeingPlatform implements DynamicPlatformPlugin {
     accessory
       .getService(Service.AccessoryInformation)!
       .setCharacteristic(Characteristic.Manufacturer, MANUFACTURER)
-      .setCharacteristic(Characteristic.Model, modelName)
+      .setCharacteristic(Characteristic.Model, fixModelPrefix(modelName))
       .setCharacteristic(Characteristic.SerialNumber, pncId)
       .setCharacteristic(Characteristic.FirmwareRevision, firmwareVersion);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,17 +254,13 @@ class AEGWellbeingPlatform implements DynamicPlatformPlugin {
         .getService(Service.CarbonDioxideSensor)!
         .updateCharacteristic(Characteristic.CarbonDioxideLevel, state.co2);
 
-      // if('doorOpen' in features && !accessory.getService(Service.DoorSensor)) 
-      //   accessory.addService(Service.DoorSensor, 'Filter Door')
+      if('doorOpen' in features && !accessory.getService(Service.ContactSensor)) 
+        accessory.addService(Service.ContactSensor, 'Filter Contact')
 
       // if('doorOpen' in features) accessory
       //   .getService(Service.DoorSensor)!
       //   .updateCharacteristic(Characteristic.PositionState,
       //     Characteristic.PositionState.STOPPED)
-      //   .updateCharacteristic(Characteristic.CurrentPosition,
-      //     state.doorOpen ? DOOR_OPEN : DOOR_CLOSED)
-      //   .updateCharacteristic(Characteristic.TargetPosition,
-      //     state.doorOpen ? DOOR_OPEN : DOOR_CLOSED)
 
       if ('envLightLevel' in features) {
         // Env Light Level needs to be tested with lux meter
@@ -280,28 +276,21 @@ class AEGWellbeingPlatform implements DynamicPlatformPlugin {
           );
       }
 
-      accessory
+      const airQualitySensor = accessory
         .getService(Service.AirQualitySensor)!
         .updateCharacteristic(
           Characteristic.AirQuality,
           this.getAirQualityLevel(state.pm25),
         )
         .updateCharacteristic(Characteristic.PM2_5Density, state.pm25)
-        .updateCharacteristic(Characteristic.PM10Density, state.pm10)
-        .updateCharacteristic(
+        .updateCharacteristic(Characteristic.PM10Density, state.pm10);
+
+      if('tvoc' in features) airQualitySensor.updateCharacteristic(
           Characteristic.VOCDensity,
           this.convertTVOCToDensity(state.tvoc),
         );
 
-      accessory
-        .getService(Service.AirPurifier)!
-        .updateCharacteristic(Characteristic.FilterLifeLevel, state.filterLife)
-        .updateCharacteristic(
-          Characteristic.FilterChangeIndication,
-          state.filterLife < 5
-            ? Characteristic.FilterChangeIndication.CHANGE_FILTER
-            : Characteristic.FilterChangeIndication.FILTER_OK,
-        )
+      const airPurifierSevice = accessory.getService(Service.AirPurifier)!
         .updateCharacteristic(
           Characteristic.Active,
           state.workMode !== WorkModes.Off,
@@ -322,7 +311,18 @@ class AEGWellbeingPlatform implements DynamicPlatformPlugin {
           Characteristic.LockPhysicalControls,
           state.safetyLock,
         )
-        .updateCharacteristic(Characteristic.SwingMode, state.ionizer);
+
+        if('filterLife' in features) airPurifierSevice
+          .updateCharacteristic(Characteristic.FilterLifeLevel, state.filterLife)
+          .updateCharacteristic(
+            Characteristic.FilterChangeIndication,
+            state.filterLife < 5
+              ? Characteristic.FilterChangeIndication.CHANGE_FILTER
+              : Characteristic.FilterChangeIndication.FILTER_OK,
+          )
+
+        if('ionizer' in features) airPurifierSevice
+          .updateCharacteristic(Characteristic.SwingMode, state.ionizer);
     });
   }
 
@@ -474,9 +474,7 @@ class AEGWellbeingPlatform implements DynamicPlatformPlugin {
     if('co2' in hasFeature) accessory.addService(Service.CarbonDioxideSensor);
     if('humidity' in hasFeature) accessory.addService(Service.HumiditySensor);
     if('envLightLevel' in hasFeature) accessory.addService(Service.LightSensor);
-    // if('doorOpen' in hasFeature) accessory
-    //   .addService(Service.Door, 'Filter Door')
-    //   .updateCharacteristic(Characteristic.PositionState, Characteristic.PositionState.STOPPED);
+    if('doorOpen' in hasFeature) accessory.addService(Service.ContactSensor, 'Filter Door')
 
     this.log.info('Services:', Object.keys(accessory.services))
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -40,6 +40,7 @@ interface Appliance {
   scheduler?: boolean;
   filterType: number;
   version: number;
+  doorOpen: boolean;
   pm1: number;
   pm25: number;
   pm10: number;


### PR DESCRIPTION
Check purifier supports data source before blindly adding it to HomeBridge